### PR TITLE
Upgrade pylint.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ httpretty==0.8.3
 coverage==3.7.1
 nose==1.3.4
 pep8==1.5.7
-pylint==1.4.0
+pylint==1.4.1
 pep257==0.3.2


### PR DESCRIPTION
@clintonb I also noticed an error with pylint, and it turns out to be affecting edx-platform as well. The fix is upgrading to pylint 1.4.1

Example stacktrace which would be resolved:
```
Traceback (most recent call last):
  File "/Users/benpatterson/workspaces/edx-server-api-client/venv/bin/pylint", line 11, in <module>
    sys.exit(run_pylint())
  File "/Users/benpatterson/workspaces/edx-server-api-client/venv/lib/python2.7/site-packages/pylint/__init__.py", line 23, in run_pylint
    Run(sys.argv[1:])
  File "/Users/benpatterson/workspaces/edx-server-api-client/venv/lib/python2.7/site-packages/pylint/lint.py", line 1281, in __init__
    linter.check(args)
  File "/Users/benpatterson/workspaces/edx-server-api-client/venv/lib/python2.7/site-packages/pylint/lint.py", line 687, in check
    self._do_check(files_or_modules)
  File "/Users/benpatterson/workspaces/edx-server-api-client/venv/lib/python2.7/site-packages/pylint/lint.py", line 809, in _do_check
    self.check_astroid_module(astroid, walker, rawcheckers, tokencheckers)
  File "/Users/benpatterson/workspaces/edx-server-api-client/venv/lib/python2.7/site-packages/pylint/lint.py", line 872, in check_astroid_module
    del astroid.file_stream
AttributeError: can't delete attribute
```